### PR TITLE
Fix double slash in version.go

### DIFF
--- a/shared/published/version.go
+++ b/shared/published/version.go
@@ -13,7 +13,7 @@ import (
 var ErrNoReleaseFound = errors.Errorf("No release found")
 
 func getAPIRelaseUrl(repo string) string {
-	return fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo)
+	return fmt.Sprintf("https://api.github.com/repos%s/releases/latest", repo)
 }
 
 func GetLastPublishedVersion(githubRepo string) (*version.Version, error) {


### PR DESCRIPTION
In project.go func resolveGitRepo() gives back a repo that starts with a slash as it converts the URL git@github.com:/flowdev/fdialog.git to "/flowdev/fdialog".
I think this is correct.

But public/version.go adds another one in the statement:
fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo)

This leads to a URL that is not found (404 HTTP error code) by the GitHub API.