### PR TITLE
Fix too modern function declaration in install.sh.tmpl

### DIFF
--- a/template/generated/install.sh.tmpl
+++ b/template/generated/install.sh.tmpl
@@ -30,7 +30,7 @@ main() {
 	mkdir -p "$bin_dir"
 	mkdir -p "$tmp_dir"
 
-	function cleanup {
+	cleanup() {
 		rm -rf $tmp_dir
 	}
 	# be a good citizen and clean up after yourself


### PR DESCRIPTION
In traditional shells like dash 'function' is not a keyword. So the cleanup function has to be declared like the main function.