### PR TITLE
Fix the double slash in project.go

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -58,7 +58,7 @@ func resolveGitRepo() (string, error) {
 
 	repo := out.String()
 	repo = strings.TrimSpace(repo)
-	repo = strings.TrimPrefix(repo, "git@github.com:")
+	repo = strings.TrimPrefix(repo, "git@github.com:/")
 	repo = strings.TrimSuffix(repo, ".git")
 
 	return repo, nil


### PR DESCRIPTION
Remove the slash at the start of every GitHub repo URL so the GithubRepo name won't start with a slash.