### PR TITLE
Fix the double slash in project.go

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -60,6 +60,9 @@ func resolveGitRepo() (string, error) {
 	repo = strings.TrimSpace(repo)
 	repo = strings.TrimPrefix(repo, "git@github.com:")
 	repo = strings.TrimSuffix(repo, ".git")
+	if repo[0] == byte('/') { // we are in happy ASCII land
+		repo = repo[1:] // remove leading slash if it exists
+	}
 
 	return repo, nil
 }


### PR DESCRIPTION
This is the **real** fix that works for all GitHub repositories.

It works in your case:

```
$ git ls-remote --get-url 
git@github.com:can3p/kleiner.git
```

But also in mine:

```
$ git ls-remote --get-url
git@github.com:/flowdev/fdialog.git
```

Thanks for checking it! :smile: 